### PR TITLE
Updated UserResponse model for `register`

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -131,7 +131,7 @@ async def create_user(user: UserCreate, request: Request, db: AsyncSession = Dep
     """
     existing_user = await UserService.get_by_username(db, user.username)
     if existing_user:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already exists")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already exist")
     
     created_user = await UserService.create(db, user.model_dump())
     if not created_user:
@@ -187,7 +187,7 @@ async def register(user_data: UserCreate, session: AsyncSession = Depends(get_as
     user = await UserService.register_user(session, user_data.dict())
     if user:
         return user
-    raise HTTPException(status_code=400, detail="Username already exists")
+    raise HTTPException(status_code=400, detail="Username and/or Email already exist")
 
 @router.post("/login/")
 async def login(login_request: LoginRequest, session: AsyncSession = Depends(get_async_db)):

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -103,7 +103,19 @@ async def test_create_user_duplicate_username(async_client, user):
     }
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 400
-    assert "Username already exists" in response.json().get("detail", "")
+    assert "Username and/or Email already exist" in response.json().get("detail", "")
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_email(async_client, user):
+    # Use a unique username but the same email as the existing 'user'
+    user_data = {
+        "username": "unique_username_123",
+        "email": user.email,
+        "password": "AnotherPassword123!",
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 400
+    assert "Username and/or Email already exist" in response.json().get("detail", "")
 
 @pytest.mark.asyncio
 async def test_create_user_invalid_email(async_client):
@@ -142,3 +154,14 @@ async def test_delete_user_does_not_exist(async_client, token):
     delete_response = await async_client.delete(f"/users/{non_existent_user_id}", headers=headers)
     assert delete_response.status_code == 404
 
+# Test for register
+@pytest.mark.asyncio
+async def test_register_success(async_client):
+    user_data = {
+        "username": "newuniqueuser123",
+        "email": "newunique@example.com",
+        "password": "SecurePassword123!",
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 200
+    assert "id" in response.json()


### PR DESCRIPTION
### Description
#### Summary
Updated register function HTTPException message to accurately reflect error message when trying to register with a duplicate username or email on the spec page. 

#### Changes Made
- __HTTPException__: Updated detail to "Username and/or Email already exist"
- Added test for duplicate email

#### Expected Behavior
- The system should clearly indicate if Username and/or Email already exist when trying to register.
