### PR TITLE
Normalized and validated `email` input at `Register` endpoint

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -103,6 +103,14 @@ class UserBase(BaseModel):
         
         return normalized_username  # Return the normalized version for storage and further handling
 
+    @validator('email')
+    def validate_email(cls, v):
+        # normalize the email to lowercase
+        normalized_email = v.lower()
+        if not re.search(r"\.(com|org|edu|net|gov)$", normalized_email):
+            raise ValueError("Email must end with one of the following domains: .com, .org, .edu, .net, .gov")
+        return normalized_email
+
     @validator('full_name')
     def validate_full_name(cls, v):
         if v and not re.match(r"^[a-zA-Z\s'-]+$", v):


### PR DESCRIPTION
### Description

**Issue Summary:**
- Previously, the `Register` endpoint did not enforce strict validation on the `email`. It was possible to have two very similar user accounts because of Case-sensitive emails: John.Doe@example.com and john.doe@example.com. This practice conflicts with tradition email registration producers as most organizers normalize emails. 

**Changes Made:**
1. Implement Email Normalization: Convert all incoming email addresses to lowercase before validation and storage to prevent case-sensitive duplicates.
2. Enforce Specific Domain Endings: Update the validation logic to ensure that all email addresses end with "`.com`, `.org`, `.edu`, `.net`, `.gov` ", reflecting our primary user base and reducing the risk of accepting less standard email formats.

These changes aim to enhance the security and consistency of user data in our application. By enforcing rules, we can avoid common issues like duplicate user accounts due to case insensitivity and ensure our data conforms to expected standards, thus improving the overall robustness of our user management processes.

**Purpose:**

Implementing these changes will improve our system's reliability in handling user registrations and ensure that our user database remains clean and efficient. This will also help in reducing user confusion and support overhead related to account management.